### PR TITLE
【質問】Vue課題4-6

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,8 +9,6 @@ import 'buefy/dist/buefy.css'
 
 Vue.use(Buefy)
 
-
-  // Your web app's Firebase configuration
   const firebaseConfig = {
     apiKey: "AIzaSyALEeG-uCX4SsTwYA51b2yka3Lb7Iv2w4Q",
     authDomain: "vuejs-http-de60c.firebaseapp.com",
@@ -19,7 +17,6 @@ Vue.use(Buefy)
     messagingSenderId: "897481049619",
     appId: "1:897481049619:web:c9e774a648e193e87c61e6"
   };
-  // Initialize Firebase
   firebase.initializeApp(firebaseConfig);
 
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,11 +7,12 @@ import firebase from 'firebase/app';
 
 Vue.use(VueRouter);
 
-const routes = [{
+const routes = [
+  {
     path: '/',
     component: Dashboard,
     meta: {
-      authFlag: true
+      requiresAuth: true,
     },
   },
   {
@@ -30,20 +31,19 @@ const router = new VueRouter({
   routes,
 });
 
-var authFlag = true;
-router.beforeEach((to, from, next) => {
-      firebase.auth().onAuthStateChanged(function (user) {
-        if (authFlag) {
-          authFlag = false;
-          if (user) {
-            next();
-          } else {
-            next('/login');
-          }
-        } else {
-          next();
-        }
-      })
-    });
+router.beforeEach((to, from, next) =>{
+  const requiresAuth = to.matched.some(record => record.meta.requiresAuth);
+  if (requiresAuth) {
+    firebase.auth().onAuthStateChanged(function (user) {
+      if (user) {
+        next();
+      } else {
+        next('/login');
+      }
+    })
+  } else {
+    next();
+  }
+});
 
-      export default router;
+export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,52 +1,47 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
+import Vue from 'vue';
+import VueRouter from 'vue-router';
 import Dashboard from '../views/Dashboard.vue';
 import Login from '../views/Login.vue';
 import Register from '../views/Register.vue';
 import firebase from 'firebase/app';
 
-
-
-Vue.use(VueRouter)
+Vue.use(VueRouter);
 
 const routes = [
   {
     path: '/',
     component: Dashboard,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true },
   },
   {
     path: '/login',
-    component: Login
+    component: Login,
   },
   {
     path: '/register',
     component: Register,
   },
-]
+];
 
 const router = new VueRouter({
   mode: 'history',
   base: process.env.BASE_URL,
-  routes
-})
+  routes,
+});
 
-router.beforeEach((to, from, next) =>{
-  const requiresAuth = to.matched.some(record => record.meta.requiresAuth);
+router.beforeEach((to, from, next) => {
+  const requiresAuth = to.matched.some((record) => record.meta.requiresAuth);
   if (requiresAuth) {
-    firebase.auth().onAuthStateChanged(function (user) {
+  firebase.auth().onAuthStateChanged(function(user) {
       if (user) {
         next();
       } else {
         next('/login');
       }
-    })
+    });
   } else {
     next();
   }
 });
 
-
-
-export default router
-
+export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,11 +7,12 @@ import firebase from 'firebase/app';
 
 Vue.use(VueRouter);
 
-const routes = [
-  {
+const routes = [{
     path: '/',
     component: Dashboard,
-    meta: { requiresAuth: true },
+    meta: {
+      authFlag: true
+    },
   },
   {
     path: '/login',
@@ -29,19 +30,20 @@ const router = new VueRouter({
   routes,
 });
 
+var authFlag = true;
 router.beforeEach((to, from, next) => {
-  const requiresAuth = to.matched.some((record) => record.meta.requiresAuth);
-  if (requiresAuth) {
-  firebase.auth().onAuthStateChanged(function(user) {
-      if (user) {
-        next();
-      } else {
-        next('/login');
-      }
+      firebase.auth().onAuthStateChanged(function (user) {
+        if (authFlag) {
+          authFlag = false;
+          if (user) {
+            next();
+          } else {
+            next('/login');
+          }
+        } else {
+          next();
+        }
+      })
     });
-  } else {
-    next();
-  }
-});
 
-export default router;
+      export default router;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -8,7 +8,12 @@ export default new Vuex.Store({
   state: {
     userName: '',
     coin: '',
+    id: '',
     userLists: [],
+    OtherUser: {
+      id: '',
+      coin: '',
+    },
   },
   getters: {
     userName: (state) => {
@@ -17,39 +22,94 @@ export default new Vuex.Store({
     coin: (state) => {
       return state.coin;
     },
+    id: (state) => {
+      return state.id;
+    },
     userLists: (state) => {
-      console.log(state.userLists);
       return state.userLists;
+    },
+    OtherUser: (state) => {
+      return state.OtherUser;
     },
   },
   mutations: {
     getUser(state, doc) {
       state.userName = doc.data().name;
       state.coin = doc.data().coin;
+      state.id = doc.data().id;
     },
     getUserLists(state, doc) {
       state.userLists.push(doc.data());
+      state.id = doc.id;
+    },
+    updateUser(state, e) {
+      state.coin - Number(e);
+      state.OtherUser.coin + Number(e);
+    },
+    updateOtherUser(state, { idList, docList, index }) {
+      state.OtherUser.id = idList[index];
+      state.OtherUser.coin = docList[index].coin;
     },
   },
   actions: {
     getUser({ commit }) {
       const AsyncGetUser = async () => {
-        const doc = await db
+        await db
           .collection('users')
           .doc(auth.currentUser.uid)
-          .get();
-        commit('getUser', doc);
+          .onSnapshot((doc) => {
+            commit('getUser', doc);
+          });
       };
       AsyncGetUser();
     },
     getUserLists({ commit }) {
       const AsyncGetUserLists = async () => {
-        const querySnapshot = await db.collection('users').get();
-        querySnapshot.forEach((doc) => {
-          commit('getUserLists', doc);
+        await db.collection('users').onSnapshot((querySnapshot) => {
+          // let users = [];
+          querySnapshot.forEach((doc) => {
+            commit('getUserLists', doc);
+          });
         });
       };
       AsyncGetUserLists();
+    },
+    updateUser({ commit }, e) {
+      const AsyncUpdateUser = async () => {
+        await db
+          .collection('users')
+          .doc(auth.currentUser.uid)
+          .update({
+            coin: this.state.coin - Number(e),
+          });
+        await db
+          .collection('users')
+          .doc(this.state.OtherUser.id)
+          .update({
+            coin: this.state.OtherUser.coin + Number(e),
+          });
+
+        const querySnapshot = await db.collection('users').get();
+        await querySnapshot.forEach((doc) => {
+          commit('getUserLists', doc);
+        });
+        await commit('updateUser', e);
+      };
+      AsyncUpdateUser();
+    },
+
+    updateOtherUser({ commit }, index) {
+      const AsyncUpdateOtherUser = async () => {
+        const idList = [];
+        const docList = [];
+        const querySnapshot = await db.collection('users').get();
+        await querySnapshot.forEach((doc) => {
+          idList.push(doc.id);
+          docList.push(doc.data());
+        });
+        await commit('updateOtherUser', { idList, docList, index });
+      };
+      AsyncUpdateOtherUser();
     },
   },
 });

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,15 +1,17 @@
 <template>
   <div>
     <div class="container">
-      <div>{{ userName }}さんようこそ</div>
-      <div>残高：{{ coin }}</div>
+      <div>{{ LoginUser.name }}さんようこそ</div>
+      <div>残高：{{ LoginUser.coin }}</div>
       <div><button @click="logOut()">ログアウト</button></div>
       <h2>ユーザー一覧</h2>
       <div v-for="(userList, index) in userLists" :key="`first-${index}`">
         <br />
         <div class="columns is-centered is-mobile">
           <div class="column is-2 has-text-left">名前：{{ userList.name }}</div>
-          <div class="column is-2 has-text-left">コイン：{{ userList.coin }}</div>
+          <div class="column is-2 has-text-left">
+            コイン：{{ userList.coin }}
+          </div>
 
           <div class="column is-2 has-text-left">
             <button @click="openModal(userList)">ボタン</button>
@@ -22,7 +24,12 @@
           <div class="column is-2 has-text-left">
             <button @click="openModalSend(index)">送る</button>
           </div>
-          <ModalSend v-show="showContentSend" @close="closeModal" :valSend="modalCoin"></ModalSend>
+          <ModalSend
+            v-show="showContentSend"
+            @close="closeModal"
+            :valSend="modalCoin"
+            :sentIndex="ReceiveIndex"
+          ></ModalSend>
         </div>
       </div>
     </div>
@@ -32,45 +39,39 @@
 </template>
 
 <script>
-import { auth } from "../main";
-import Modal from "@/views/Modal";
-import ModalSend from "@/views/ModalSend";
+import { auth } from '../main';
+import Modal from '@/views/Modal';
+import ModalSend from '@/views/ModalSend';
 export default {
   components: {
     Modal,
-    ModalSend
+    ModalSend,
   },
 
   data() {
     return {
       showContent: false,
       showContentSend: false,
-      modalItem: "",
-      modalCoin:"",
-
+      modalItem: '',
+      modalCoin: '',
+      ReceiveIndex: '',
     };
   },
   created() {
-    this.$store.dispatch("getUser");
-    this.$store.dispatch("getUserLists");
+    this.$store.dispatch('getUser');
+    this.$store.dispatch('getUserLists');
   },
   computed: {
-    userName() {
-      return this.$store.getters.userName;
-    },
-    coin() {
-      return this.$store.getters.coin;
-    },
-    id() {
-      return this.$store.getters.coin;
+    LoginUser() {
+      return this.$store.getters.LoginUser;
     },
     userLists() {
       return this.$store.getters.userLists;
-    }
+    },
   },
   methods: {
     logOut: async function() {
-      await auth.signOut();
+      await auth.signOut().then(this.$store.dispatch('ResetUserLists'));
     },
     openModal(userList) {
       this.showContent = true;
@@ -78,15 +79,13 @@ export default {
     },
     openModalSend(index) {
       this.showContentSend = true;
-      this.modalCoin = this.coin
-      console.log(index)
-      this.$store.dispatch('updateOtherUser',index)
-
+      this.modalCoin = this.coin;
+      this.$store.dispatch('getReceiveUserIndex', index);
     },
     closeModal() {
       this.showContent = false;
       this.showContentSend = false;
     },
-  }
+  },
 };
 </script>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,47 +1,58 @@
 <template>
   <div>
-      <div class="container">
-    <div>{{ userName }}さんようこそ</div>
-    <div>残高：{{ coin }}</div>
-    <div><button @click="logOut()">ログアウト</button></div>
-    <h2>ユーザー一覧</h2>
-    <div v-for="(userList,index) in userLists" :key="`first-${index}`">
-      <br />
+    <div class="container">
+      <div>{{ userName }}さんようこそ</div>
+      <div>残高：{{ coin }}</div>
+      <div><button @click="logOut()">ログアウト</button></div>
+      <h2>ユーザー一覧</h2>
+      <div v-for="(userList, index) in userLists" :key="`first-${index}`">
+        <br />
         <div class="columns is-centered is-mobile">
           <div class="column is-2 has-text-left">名前：{{ userList.name }}</div>
+          <div class="column is-2 has-text-left">コイン：{{ userList.coin }}</div>
 
           <div class="column is-2 has-text-left">
             <button @click="openModal(userList)">ボタン</button>
-        </div>
+          </div>
           <Modal
             :val="modalItem"
             v-show="showContent"
             @close="closeModal"
           ></Modal>
+          <div class="column is-2 has-text-left">
+            <button @click="openModalSend(index)">送る</button>
           </div>
+          <ModalSend v-show="showContentSend" @close="closeModal" :valSend="modalCoin"></ModalSend>
+        </div>
       </div>
     </div>
+
     <router-link to="/register">新規登録はこちらから</router-link>
   </div>
 </template>
 
 <script>
-import { auth } from '../main';
-import Modal from '@/views/Modal';
+import { auth } from "../main";
+import Modal from "@/views/Modal";
+import ModalSend from "@/views/ModalSend";
 export default {
   components: {
     Modal,
+    ModalSend
   },
 
   data() {
     return {
       showContent: false,
-      modalItem: '',
+      showContentSend: false,
+      modalItem: "",
+      modalCoin:"",
+
     };
   },
   created() {
-    this.$store.dispatch('getUser');
-    this.$store.dispatch('getUserLists');
+    this.$store.dispatch("getUser");
+    this.$store.dispatch("getUserLists");
   },
   computed: {
     userName() {
@@ -50,9 +61,12 @@ export default {
     coin() {
       return this.$store.getters.coin;
     },
+    id() {
+      return this.$store.getters.coin;
+    },
     userLists() {
       return this.$store.getters.userLists;
-    },
+    }
   },
   methods: {
     logOut: async function() {
@@ -62,10 +76,17 @@ export default {
       this.showContent = true;
       this.modalItem = userList;
     },
+    openModalSend(index) {
+      this.showContentSend = true;
+      this.modalCoin = this.coin
+      console.log(index)
+      this.$store.dispatch('updateOtherUser',index)
+
+    },
     closeModal() {
       this.showContent = false;
+      this.showContentSend = false;
     },
-  },
+  }
 };
 </script>
-

--- a/src/views/ModalSend.vue
+++ b/src/views/ModalSend.vue
@@ -2,8 +2,7 @@
   <div>
     <div id="overlay">
       <div id="content">
-        <p>あなたの残高:{{ valSend }}</p>
-        <p>{{ sendedCoin }}</p>
+        <p>あなたの残高:{{ LoginUser.coin }}</p>
         <form>
           <input type="number" value="sendCoin" v-model="sendedCoin" />
           <button
@@ -25,13 +24,16 @@
 <script>
 export default {
   name: 'ModalSend',
-  props: ['valSend'],
+  props: ['sentIndex'],
   data() {
     return {
       sendedCoin: '',
     };
   },
   computed: {
+    LoginUser() {
+      return this.$store.getters.LoginUser;
+    },
     userLists() {
       return this.$store.getters.userLists;
     },
@@ -39,7 +41,7 @@ export default {
 
   methods: {
     updateCoin() {
-      this.$store.dispatch('updateUser', this.sendedCoin);
+      this.$store.dispatch('updateUsers', { sendedCoin: this.sendedCoin });
       this.sendedCoin = '';
     },
   },

--- a/src/views/ModalSend.vue
+++ b/src/views/ModalSend.vue
@@ -1,0 +1,75 @@
+<template>
+  <div>
+    <div id="overlay">
+      <div id="content">
+        <p>あなたの残高:{{ valSend }}</p>
+        <p>{{ sendedCoin }}</p>
+        <form>
+          <input type="number" value="sendCoin" v-model="sendedCoin" />
+          <button
+            type="submit"
+            @click.prevent="
+              updateCoin();
+              $emit('close');
+            "
+          >
+            送信
+          </button>
+        </form>
+        <button @click="$emit('close')">閉じる</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ModalSend',
+  props: ['valSend'],
+  data() {
+    return {
+      sendedCoin: '',
+    };
+  },
+  computed: {
+    userLists() {
+      return this.$store.getters.userLists;
+    },
+  },
+
+  methods: {
+    updateCoin() {
+      this.$store.dispatch('updateUser', this.sendedCoin);
+      this.sendedCoin = '';
+    },
+  },
+};
+</script>
+
+<style>
+#overlay {
+  z-index: 1;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#content {
+  z-index: 2;
+  width: 50%;
+  padding-top: 5em;
+  padding-bottom: 5em;
+  text-align: center;
+  background-color: aliceblue;
+}
+
+#content > img {
+  width: 95%;
+}
+</style>


### PR DESCRIPTION
以下2点質問させてください。

1,表示させたユーザーリストが、再度重複して一覧表示されてしまう。
→重複して表示させないにはどうすれば良いでしょうか？

▼ 発生条件
・ログアウト後に、再度ログインしDashboard.vueが表示されると発生。
・新規ユーザー登録後に、Dashboard.vueが表示されると発生。
※ 上記2つの条件共、リロードすれば正しく表示されます。
※相談詳細 https://b-teck.slack.com/archives/G01QA1678P8/p1622861564050900




2,投げ銭実行後、実行したログインユーザーの残高は即時反映されるが、投げ銭を受けたユーザーの残高はリロードしないと反映しない。
→即時反映するためにはどうすれば良いでしょうか？

▼ 試したこと
以下を参考を中心に、firestoreの.onSnapshotメソッドや、.docChanges()メソッドで、firebase側で変更があれば即時反映するよう試みましたが、リロードしないと反映できないままでした。

https://firebase.google.com/docs/firestore/query-data/listen#view_changes_between_snapshots



コミットID
a5918a147b16d035f1aeb4d45a5374eeb7830c13